### PR TITLE
fix(windows) shortcut path must be quoted

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,9 @@ var check = function() {
   if (process.platform === 'win32') {
     var cmd = process.argv[1];
     debug('processing squirrel command `%s`', cmd);
-    var target = path.basename(process.execPath);
+
+    var target = '"' + path.basename(process.execPath) +'"';
+
     if (cmd === '--squirrel-install' || cmd === '--squirrel-updated') {
       run(['--createShortcut', target], app.quit);
       return true;


### PR DESCRIPTION
I suspect this will fix the shortcut when the app name is "MongoDB Scout.exe"
