### PR TITLE
Add explicit icon path during --createShortcut on install

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ var check = function(options) {
       if(iconPath) args.push('--i=' + iconPath);
 
       run(args, app.quit);
-      options && options.onInstall && options.onInstall();
+      options && options.onInstall && options.onInstall(cmd === '--squirrel-install');
       return true;
     }
     if (cmd === '--squirrel-uninstall') {

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var path = require('path');
 var spawn = require('child_process').spawn;
 var debug = require('debug')('electron-squirrel-startup');
 var app = require('electron').app;
+var fs = require('fs');
 
 var run = function(args, done) {
   var updateExe = path.resolve(path.dirname(process.execPath), '..', 'Update.exe');
@@ -11,14 +12,31 @@ var run = function(args, done) {
   }).on('close', done);
 };
 
+var copyIcon = function(sourceFile) {
+  var output, targetFile;
+  try {
+    targetFile = path.resolve(path.dirname(process.execPath), '..', 'app.ico');
+    fs.writeFileSync(targetFile, fs.readFileSync(sourceFile));
+    output = targetFile;
+  } catch(err) {
+    debug('Failed to copy icon `%s` to `%s` %s', sourceFile, targetFile, err.message);
+  }
+  return output;
+};
+
 var check = function(options) {
   if (process.platform === 'win32') {
-    var cmd = process.argv[1];
+    var cmd = process.argv[1], args;
     debug('processing squirrel command `%s`', cmd);
     var target = path.basename(process.execPath);
 
     if (cmd === '--squirrel-install' || cmd === '--squirrel-updated') {
-      run(['--createShortcut=' + target + ''], app.quit);
+      args = ['--createShortcut=' + target + ''];
+      
+      var iconPath = options && options.iconPath && copyIcon(options.iconPath);
+      if(iconPath) args.push('--i=' + iconPath);
+
+      run(args, app.quit);
       return true;
     }
     if (cmd === '--squirrel-uninstall') {

--- a/index.js
+++ b/index.js
@@ -50,18 +50,18 @@ var check = function(options) {
         args.push('--i=' + iconPath);
       }
 
-      run(args, app.quit);
       options && options.onInstall && options.onInstall(cmd === '--squirrel-install');
+      run(args, app.quit);
       return true;
     }
     if (cmd === '--squirrel-uninstall') {
-      run(['--removeShortcut=' + target + ''], app.quit);
       options && options.onUninstall && options.onUninstall();
+      run(['--removeShortcut=' + target + ''], app.quit);
       return true;
     }
     if (cmd === '--squirrel-obsolete') {
-      app.quit();
       options && options.onObsolete && options.onObsolete();
+      app.quit();
       return true;
     }
   }

--- a/index.js
+++ b/index.js
@@ -37,14 +37,17 @@ var check = function(options) {
       if(iconPath) args.push('--i=' + iconPath);
 
       run(args, app.quit);
+      options && options.onInstall && options.onInstall();
       return true;
     }
     if (cmd === '--squirrel-uninstall') {
       run(['--removeShortcut=' + target + ''], app.quit);
+      options && options.onUninstall && options.onUninstall();
       return true;
     }
     if (cmd === '--squirrel-obsolete') {
       app.quit();
+      options && options.onObsolete && options.onObsolete();
       return true;
     }
   }

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ var run = function(args, done) {
   }).on('close', done);
 };
 
-var check = function() {
+var check = function(options) {
   if (process.platform === 'win32') {
     var cmd = process.argv[1];
     debug('processing squirrel command `%s`', cmd);
@@ -33,4 +33,4 @@ var check = function() {
   return false;
 };
 
-module.exports = check();
+module.exports = check;

--- a/index.js
+++ b/index.js
@@ -13,9 +13,15 @@ var run = function(args, done) {
 };
 
 var copyIcon = function(sourceFile) {
-  var output, targetFile;
+  var output, targetFile, targetFileName,
+    reservedName = "app.ico"; // used by Squirrel uninstall regkey. Will cause conflict if pre-exists.
   try {
-    targetFile = path.resolve(path.dirname(process.execPath), '..', 'app.ico');
+    // Build target path
+    targetFileName = path.basename(process.execPath, '.exe') + '.ico';
+    if(targetFileName.toLowerCase() == reservedName.toLowerCase()) targetFileName = '_' + targetFileName;
+    targetFile = path.resolve(path.dirname(process.execPath), '..', targetFileName);
+    
+    // Perform copy
     fs.writeFileSync(targetFile, fs.readFileSync(sourceFile));
     output = targetFile;
   } catch(err) {


### PR DESCRIPTION
As-is, this module creates shortcuts that point the the EXE in the version folder. This means that all shortcuts have invalid icons after each upgrade, and all shortcuts must be updated. Unfortunately, Windows' shell caches some of this information, does fancy stuff for shortcut-to-exe matching, etc. Further, the user may have copied a shortcut, in which case it will just go bad.

A better solution is to use Squirrel's --icon flag and copy an icon to a known place. Squirrel already uses app.ico in the Update.exe directory for uninstall icon, so seems like a good place. (Though-- that icon will fail to be placed if it doesn't download at time of install, oddly.)

NOTE: This is a breaking change so not really eligible for merge :( What do you recommend / Any review suggestions?

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb-js/electron-squirrel-startup/10)

<!-- Reviewable:end -->
