### PR TITLE
Updated the README to include Babel/ES6 usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ add the following to the top of your `main.js` and you're good to go:
 ```js
 if(require('electron-squirrel-startup')) return;
 ```
+For Babel/ES6:
+
+```js
+const { app } = require('electron');
+// ....
+if(require('electron-squirrel-startup')) app.quit();
+```
 
 ## Read More
 


### PR DESCRIPTION
The usage example in the README results in a syntax error for Babel/ES6 users, as reported by @matthiaslau in #15:

`SyntaxError: 'return' outside of function.`