### PR TITLE
Add ability to pass in own path for target

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,26 +11,29 @@ var run = function(args, done) {
   }).on('close', done);
 };
 
-var check = function(pth) {
+var check = function(pth,callback) {
   if (process.platform === 'win32') {
     var cmd = process.argv[1];
     debug('processing squirrel command `%s`', cmd);
     var target = pth || path.basename(process.execPath);
 
     if (cmd === '--squirrel-install' || cmd === '--squirrel-updated') {
-      run(['--createShortcut=' + target + ''], app.quit);
-      return true;
+      fs.unlink(path.resolve('C:/Users/Public/Desktop/SmarterProctoring.lnk'),(err,res) => {
+        run(['--createShortcut=' + target + ''], app.quit);
+        return callback(true);
+      })
+      
     }
     if (cmd === '--squirrel-uninstall') {
       run(['--removeShortcut=' + target + ''], app.quit);
-      return true;
+      return callback(true);
     }
     if (cmd === '--squirrel-obsolete') {
       app.quit();
-      return true;
+      return callback(true);
     }
   }
-  return false;
+  return callback(false);
 };
 
 module.exports = check;

--- a/index.js
+++ b/index.js
@@ -33,4 +33,4 @@ var check = function(pth) {
   return false;
 };
 
-module.exports = check();
+module.exports = check;

--- a/index.js
+++ b/index.js
@@ -11,11 +11,11 @@ var run = function(args, done) {
   }).on('close', done);
 };
 
-var check = function() {
+var check = function(pth) {
   if (process.platform === 'win32') {
     var cmd = process.argv[1];
     debug('processing squirrel command `%s`', cmd);
-    var target = path.basename(process.execPath);
+    var target = pth || path.basename(process.execPath);
 
     if (cmd === '--squirrel-install' || cmd === '--squirrel-updated') {
       run(['--createShortcut=' + target + ''], app.quit);


### PR DESCRIPTION
We are using a custom solution for our autoUpdater/builder where the calling process returned from execPath is not where the new updated app is located(located in folder app-0.0.1/app.exe) and it would be very helpful to be able to override this portion. For now I have the functions from this module pulled out into my own main.js but would like to start using it again.

Thanks!